### PR TITLE
fix windows build with conda 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ media/rodrigo.jpeg
 media/chico.jpg
 media/natorf2.jpg
 media/tiagor.jpg
+.vscode/settings.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astroid==2.3.3
+astroid==2.5.3
 attrs==19.3.0
 backcall==0.1.0
 bleach==3.1.4
@@ -27,16 +27,16 @@ json5==0.9.4
 jsonschema==3.2.0
 jupyter-client==6.1.2
 jupyter-core==4.6.3
-jupyterlab==2.0.1
-jupyterlab-server==1.1.0
+jupyterlab==3.0.14
+jupyterlab-server==2.4.0
 kiwisolver==1.2.0
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 matplotlib==3.2.1
 mccabe==0.6.1
 mistune==0.8.4
-mkl-fft==1.0.15
-mkl-random==1.1.0
+mkl-fft==1.3.0
+mkl-random==1.2.1
 mkl-service==2.3.0
 nbconvert==5.6.1
 nbformat==5.0.5
@@ -57,7 +57,7 @@ ptyprocess==0.6.0
 pycparser==2.18
 pyfakewebcam==0.1.0
 Pygments==2.6.1
-pylint==2.4.4
+pylint==2.7.4
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
 pyrsistent==0.16.0
@@ -78,7 +78,7 @@ terminado==0.8.3
 testpath==0.4.4
 #torch==1.4.0
 #torchvision==0.5.0
-tornado==6.0.4
+tornado==6.1
 tqdm==4.45.0
 traitlets==4.3.3
 urllib3==1.25.7


### PR DESCRIPTION
This PR updates several packages and enables the repo to build under windows 10 with conda 3.8 per the readme. Able to run faceit_live.py without error, but not seeing any results via setting OBS Cam in  Zoom, Google Hangouts etc. Can you record a video of running from the command line under ubuntu and the stream/camera windows appearing per the readme?

This PR appears to potentially address the following open issues:
https://github.com/alew3/faceit_live3/issues/32
https://github.com/alew3/faceit_live3/issues/28
https://github.com/alew3/faceit_live3/issues/20